### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ demo:
 
 ## Usage
 #### Step 1
-#####Gradle & Maven
+##### Gradle & Maven
 ```groovy
 dependencies {
     // I have released it but it may not update to maven center, if your maven can not find it, wait a moment please.
@@ -25,7 +25,7 @@ dependencies {
 ```
 
 
-#####Or
+##### Or
 
 Import the library, then add it to your `/settings.gradle` and `/app/build.gradle`, if you don't know how to do it, you can read my blog for help.
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
